### PR TITLE
Extending productsFilter flag 12 description

### DIFF
--- a/README.md
+++ b/README.md
@@ -255,7 +255,7 @@ Flag number | mode of transport
  9 | subway
  10 | tram
  11 | ?
- 12 | ?
+ 12 | AST
  13 | Westbahn
  14 | ?
  15 | ?


### PR DESCRIPTION
I found that while disabling all filters except the unknown ones, that the `AST` transportation was always shown. By disabling the unknown filter one at a time I found that its indicated by flag 12.

I don't know where and when this type of transportation is available. So if you want to reproduce the result I recommend doing this at around 22:00 for the station "Wiener Neustadt" (evaId: `1130401`)